### PR TITLE
Update README to use correct unpkg URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Browser:
 
 ```js
 <script type="module">
-  import * as webauthn from 'https://unpkg.com/@passwordless-id/webauthn@latest/dist/passwordless.min.js'
+  import * as webauthn from 'https://unpkg.com/@passwordless-id/webauthn@latest/dist/webauthn.min.js'
 </script>
 ```
 


### PR DESCRIPTION
The README currently links to file `passwordless.min.js` which is not found.  The [dist](https://unpkg.com/@passwordless-id/webauthn@latest/dist/) directory contains `webauthn.min.js` and the samples use `webauthn` files.
