### PR TITLE
Change package main to dist/webauthn.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@passwordless-id/webauthn",
   "version": "0.0.10",
   "description": "A small wrapper around the webauthn protocol to make one's life easier.",
-  "main": "src/index.ts",
+  "main": "dist/webauthn.min.js",
   "scripts": {
     "build": "esbuild src/index.ts --platform=neutral --bundle --sourcemap --minify --target=es2022 --outfile=dist/webauthn.min.js",
     "dev": "http-server"


### PR DESCRIPTION
The current package.json is reference `src/index.ts`

https://github.com/passwordless-id/webauthn/blob/9d47c5133ddc39bc51a2fe7af300fecd73afc031/package.json#L5

I don't think packages should reference `.ts` files. Especially if they are intended to be used in a browser environment which doesn't natively compile typescript.
I think it should be referencing `dist/webauthn.min.js`