### PR TITLE
Only include dist folder in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "esbuild": "^0.15.8",
     "http-server": "^14.1.1",
     "typescript": "^4.8.3"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
When inspecting the package in issue #8 I noticed the `demos` folder is also being included in the package which I didn't think was intentional.

![image](https://user-images.githubusercontent.com/2856501/202967023-39fac316-e9f3-4753-a348-8404bfa7ac3f.png)

Given the `dist` folder has all the code, sourcemaps, and types, it should be sufficient as is. Including the demos bloats the size of the package and changes to the demos shouldn't affect the package.