### PR TITLE
feat: added optional `userHandle` field to authentication response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@passwordless-id/webauthn",
-  "version": "1.3.3",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@passwordless-id/webauthn",
-      "version": "1.3.3",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-typescript": "^7.21.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -203,6 +203,7 @@ export async function authenticate(credentialIds :string[], challenge :string, o
         authenticatorData: utils.toBase64url(response.authenticatorData),
         clientData: utils.toBase64url(response.clientDataJSON),
         signature: utils.toBase64url(response.signature),
+        userHandle: response.userHandle ? utils.toBase64url(response.userHandle) : null
     }
 
     return authentication

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface AuthenticationEncoded {
     authenticatorData: string
     clientData: string
     signature: string
+    userHandle?: string | null
 }
 
 export interface AuthenticationParsed {


### PR DESCRIPTION
# What

The authentication response does not contain the optional `userHandle` field.

# Why

The original `AssertionResponse` object also contains `userHandle` field based on [Webauthn spec](https://w3c.github.io/webauthn/#dictdef-authenticatorassertionresponsejson). According to docs:

`The authenticator MUST always return a userHandle if the allowCredentials option used in the authentication ceremony is empty, and MAY return one otherwise.` However, in the current library the userHandle is never returned. userHandle field returns the `userId` provided in registration if the credential is discoverable (otherwise it is null) and we might need this value while authentication.

# How

Add optional userHandle field to `AuthenticationEncoded` type and authentication response of webauthn client.

 