### PR TITLE
Add support for abort signal

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -105,7 +105,7 @@ export async function register(username :string, challenge :string, options? :Re
     if(options.debug)
         console.debug(creationOptions)
 
-    const credential = await navigator.credentials.create({publicKey: creationOptions}) as any //PublicKeyCredential
+    const credential = await navigator.credentials.create({publicKey: creationOptions, signal: options.signal}) as any //PublicKeyCredential
     
     if(options.debug)
         console.debug(credential)
@@ -190,7 +190,11 @@ export async function authenticate(credentialIds :string[], challenge :string, o
     if(options.debug)
         console.debug(authOptions)
 
-    let auth = await navigator.credentials.get({publicKey: authOptions, mediation: options.mediation}) as PublicKeyCredential
+    let auth = await navigator.credentials.get({
+      publicKey: authOptions,
+      mediation: options.mediation,
+      signal: options.signal,
+    }) as PublicKeyCredential
     
     if(options.debug)
         console.debug(auth)

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface CommonOptions {
   authenticatorType ?:AuthType
   timeout ?:number
   debug ?:boolean
+  signal ?:AbortSignal
 }
 
 


### PR DESCRIPTION
Hi,

Adds support for passing a `AbortSignal` via the optional `signal` property. This can be used to cancel credential requests, like when using `mediation: 'conditional'`.

A react hook example:

```tsx
useEffect(() => {
  const abortController = new AbortController();

  async function startDeviceAuthentication() {
    const authentication = await client.authenticate([], "...", {
      authenticatorType: 'auto',
      userVerification: 'required',
      timeout: 60000,
      mediation: 'conditional',
      signal: abortController.signal,
    });

    // ...
  }

  void startDeviceAuthentication();

  return () => {
    abortController.abort();
  };
}, []);
```

As we add a new optional parameter, this should be backwards compatible.