### PR TITLE
fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Try out the playground to see how this library works:
 
 ### *[Testing Playground](https://webauthn.passwordless.id/demos/playground.html)*
 
-Other demos with minial examples:
+Other demos with minimal examples:
 
 - [Basic Demo](https://webauthn.passwordless.id/demos/basic.html)
 - [Minimal Example (CDN)](https://webauthn.passwordless.id/demos/example-cdn.html)
@@ -85,7 +85,7 @@ client.isAvailable()
 ```
 
 Returns `true` or `false` depending on whether the Webauthn protocol is available on this platform/browser.
-Particularly linux and "exotic" web browsers might not have support yet.
+Particularly linux and "exotic" web browsers might not have supported yet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ This library is a wrapper around the WebAuthn protocol.
 It is the technical foundation for strong authentication.
 No more, no less.
 
-[Passwordless.ID](https://passwordless.id) is a service. It provides is all the other things required for a complete authentication system:
+[Passwordless.ID](https://passwordless.id) is a service. It provides all the other things required for a complete authentication system:
 
 - multiple registered devices per account
 - user profile

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Parameters:
 
 - `username`: The desired username.
 - `challenge`: A server-side randomly generated string.
-- `options`: See [below](#options).
+- `options`: See [below](#common-options).
 
 The `registration` object looks like this:
 
@@ -278,7 +278,7 @@ Parameters:
 
 - `credentialIds`: The list of credential IDs that can be used for signing.
 - `challenge`: A server-side randomly generated string, the base64url encoded version will be signed.
-- `options`: See [below](#options).
+- `options`: See [below](#common-options).
 
 
 ### 3. In the server, load the credential key


### PR DESCRIPTION
There's another typo in https://passwordless.id/protocols/webauthn/overview.svg, that `Device regsitered` -> `Device registered`.