### PR TITLE
fix: Cancel previous authenticate session when new is started

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -169,11 +169,9 @@ export async function authenticate(options: AuthenticateOptions): Promise<Authen
 
     console.debug(authOptions)
 
-    if (options.autocomplete) {
-        if(ongoingAuth != null)
-            ongoingAuth.abort('Cancel ongoing authentication')
-        ongoingAuth = new AbortController();
-    }
+    if(ongoingAuth != null)
+        ongoingAuth.abort('Cancel ongoing authentication')
+    ongoingAuth = new AbortController();
     
     const raw = await navigator.credentials.get({
         publicKey: authOptions,


### PR DESCRIPTION
Currently only autocomplete: true auth session will abort previous one.

A common scenario is to have autocomplete session "running" but still present to user with additional "Login with passkey" option.