### PR TITLE
Allow passing custom AbortController to register and authenticate functions without breaking existing behavior

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface CommonOptions {
 export interface RegisterOptions extends CommonOptions {
   attestation?: boolean
   discoverable?: ResidentKeyRequirement
+  signal?: AbortSignal
   user: string | User
 }
 
@@ -56,6 +57,7 @@ export interface CredentialDescriptor {
 export interface AuthenticateOptions extends CommonOptions {
   allowCredentials?: (CredentialDescriptor | string)[]
   autocomplete?: boolean
+  signal?: AbortSignal
 }
 
 


### PR DESCRIPTION
### Motivation

This Pull Request adds the ability to pass a custom `AbortController` to the `register` and `authenticate` functions. This allows finer control over the authentication lifecycle, which is helpful in applications that manage multiple authentication processes simultaneously or need to handle aborting operations in a specific way.

### Changes Made
- Added an optional `signal` parameter to `RegisterOptions` and `AuthenticateOptions` interfaces.
- Modified the `register` and `authenticate` functions to use the provided `signal` if available.
- If a `signal` is provided in the options, it uses that `AbortSignal`.
- If no `signal` is provided, it falls back to using the existing global `ongoingAuth` logic.
- Maintained backward compatibility by preserving existing behavior when no `signal` is provided.
- Updated documentation and comments to reflect the new optional `signal` parameter.

### Backward Compatibility
- Existing users who do not pass a `signal` will experience the same behavior as before.
- The global `ongoingAuth` variable is still used when no custom `AbortController` is provided.
- This change should not break any existing implementations.

### Additional Notes
- It addresses issues where the global `ongoingAuth` could cause unintended side effects in complex applications.
- For simplicity and clarity, it's often better to let users manage their own `AbortController` instances. I am willing to submit a PR to remove the global controller altogether, but this would be a breaking change, so I have not done it here.

