### PR TITLE
Add excludeCredentials to Passkey Creation Process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@passwordless-id/webauthn",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@passwordless-id/webauthn",
-      "version": "2.0.0",
+      "version": "2.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -16,6 +16,9 @@
         "jest-ts-webcompat-resolver": "^1.0.0",
         "ts-jest": "^29.1.3",
         "typescript": "^5.4.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/passwordless-id"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,6 +92,7 @@ export async function register(options: RegisterOptions): Promise<RegistrationJS
             residentKey: options.discoverable ?? 'preferred', // see https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#residentkey
             requireResidentKey: (options.discoverable === 'required') // mainly for backwards compatibility, see https://www.w3.org/TR/webauthn/#dictionary-authenticatorSelection
         },
+        excludeCredentials: options?.excludeCredentials?.map(toPublicKeyCredentialDescriptor),
         attestation: "direct"
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,9 +33,10 @@ export interface CommonOptions {
 }
 
 export interface RegisterOptions extends CommonOptions {
-  attestation?: boolean
-  discoverable?: ResidentKeyRequirement
-  user: string | User
+  attestation?: boolean;
+  discoverable?: ResidentKeyRequirement;
+  excludeCredentials?: (CredentialDescriptor | string)[];
+  user: string | User;
 }
 
 


### PR DESCRIPTION
This PR introduces the `excludeCredentials` property to the passkey creation flow. This feature enhances the security and usability of the passkey creation process by preventing duplicate registrations of credentials associated with the same user.