### PR TITLE
chore: Update import statements to include file extensions

### DIFF
--- a/src/authenticators.ts
+++ b/src/authenticators.ts
@@ -1,4 +1,4 @@
-import { authenticatorMetadata } from './authenticatorMetadata'
+import { authenticatorMetadata } from './authenticatorMetadata.js'
 
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { AuthenticateOptions, AuthenticationJSON, Base64URLString, CredentialDescriptor, ExtendedAuthenticatorTransport, PublicKeyCredentialHints, RegisterOptions, RegistrationJSON, User, WebAuthnCreateOptions, WebAuthnGetOptions } from './types.js'
-import * as utils from './utils'
+import * as utils from './utils.js'
 
 /**
  * Returns whether passwordless authentication is available on this browser/platform or not.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import * as client from './client';
-import * as server from './server';
-import * as parsers from './parsers';
-import * as utils from './utils';
-import { authenticatorMetadata } from './authenticatorMetadata'
+import * as client from './client.js';
+import * as server from './server.js';
+import * as parsers from './parsers.js';
+import * as utils from './utils.js';
+import { authenticatorMetadata } from './authenticatorMetadata.js'
 
 export { client, server, parsers, utils, authenticatorMetadata }
 

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,6 +1,6 @@
-import * as utils from './utils'
-import { Base64URLString, CollectedClientData, NamedAlgo, AuthenticatorParsed, RegistrationJSON, RegistrationInfo, UserInfo, AuthenticationInfo, AuthenticationJSON } from './types'
-import { authenticatorMetadata } from './authenticatorMetadata'
+import * as utils from './utils.js'
+import { Base64URLString, CollectedClientData, NamedAlgo, AuthenticatorParsed, RegistrationJSON, RegistrationInfo, UserInfo, AuthenticationInfo, AuthenticationJSON } from './types.js'
+import { authenticatorMetadata } from './authenticatorMetadata.js'
 
 const utf8Decoder = new TextDecoder('utf-8')
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
-import { parsers } from "./index";
-import { parseAuthenticator, parseClient, toAuthenticationInfo } from "./parsers";
-import { AuthenticationJSON, NamedAlgo, RegistrationJSON, RegistrationInfo, AuthenticationInfo, Base64URLString, CollectedClientData, UserInfo, CredentialInfo, AuthenticatorInfo, AuthenticatorParsed } from "./types";
-import * as utils from './utils'
+import { parsers } from "./index.js";
+import { parseAuthenticator, parseClient, toAuthenticationInfo } from "./parsers.js";
+import { AuthenticationJSON, NamedAlgo, RegistrationJSON, RegistrationInfo, AuthenticationInfo, Base64URLString, CollectedClientData, UserInfo, CredentialInfo, AuthenticatorInfo, AuthenticatorParsed } from "./types.js";
+import * as utils from './utils.js'
 
 
 export function randomChallenge() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@
      Encoding/Decoding Utils
 ********************************/
 
-import { Base64URLString, NamedAlgo } from "./types"
+import { Base64URLString, NamedAlgo } from "./types.js"
 
 
 export function toBuffer(txt :string) :ArrayBuffer {


### PR DESCRIPTION
Add explicit file extensions to the imports so the file extensions appear in the ESM build output.

![image](https://github.com/user-attachments/assets/5ca3c5c5-873a-4a5c-af9d-074f96ee5de1)

Fixes #90 